### PR TITLE
fix: Add #if swift check for Combine publishers (#775)

### DIFF
--- a/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
+++ b/Amplify/Categories/API/Operation/AmplifyOperation+APIPublishers.swift
@@ -10,6 +10,9 @@ import Foundation
 
 // MARK: - GraphQLOperation
 
+// The overrides require a feature and bugfix introduced in Swift 5.2
+#if swift(>=5.2)
+
 @available(iOS 13.0, *)
 public extension GraphQLOperation {
     /// Publishes the final result of the operation
@@ -104,3 +107,5 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+
+#endif

--- a/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
+++ b/Amplify/Categories/Auth/Operation/AmplifyOperation+AuthPublishers.swift
@@ -10,6 +10,9 @@ import Foundation
 
 // MARK: - AuthAttributeResendConfirmationCodeOperation
 
+// The overrides require a feature and bugfix introduced in Swift 5.2
+#if swift(>=5.2)
+
 @available(iOS 13.0, *)
 public extension AmplifyOperation
     where
@@ -273,3 +276,5 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+
+#endif

--- a/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
+++ b/Amplify/Categories/Predictions/Operation/AmplifyOperation+PredictionsPublishers.swift
@@ -10,6 +10,9 @@ import Foundation
 
 // MARK: - PredictionsIdentifyOperation
 
+// The overrides require a feature and bugfix introduced in Swift 5.2
+#if swift(>=5.2)
+
 @available(iOS 13.0, *)
 public extension AmplifyOperation
     where
@@ -77,3 +80,5 @@ public extension AmplifyOperation
         internalResultPublisher
     }
 }
+
+#endif

--- a/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
+++ b/Amplify/Categories/Storage/Operation/Operation+StoragePublishers.swift
@@ -10,6 +10,9 @@ import Foundation
 
 // MARK: - StorageDownloadDataOperation
 
+// The overrides require a feature and bugfix introduced in Swift 5.2
+#if swift(>=5.2)
+
 @available(iOS 13.0, *)
 public extension AmplifyInProcessReportingOperation
     where
@@ -145,3 +148,5 @@ public extension AmplifyInProcessReportingOperation
         internalInProcessPublisher
     }
 }
+
+#endif


### PR DESCRIPTION
Prevents errors for customers compiling with Swift toolchains < 5.2

refs:
- #717
- #740
- #744

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
